### PR TITLE
Add indexes to improve address lookup performance

### DIFF
--- a/import/ruian_transform.sql
+++ b/import/ruian_transform.sql
@@ -64,3 +64,7 @@ ALTER TABLE `ruian_ulice`
 ADD PRIMARY KEY `id` (`id`),
 ADD INDEX `casti_obce_id` (`casti_obce_id`),
 ADD INDEX `obec_id` (`obec_id`);
+
+ALTER TABLE ruian_adresy ADD FULLTEXT(nazev_ulice, nazev_obce, nazev_casti_obce);
+CREATE INDEX idx_cislo ON ruian_adresy (cislo_domovni, cislo_orientacni);
+


### PR DESCRIPTION
Add indexes to improve address lookup performance

- add FULLTEXT index on nazev_ulice, nazev_obce and nazev_casti_obce to enable efficient full-text search (MATCH ... AGAINST)
- add composite index idx_cislo on (cislo_domovni, cislo_orientacni) to speed up lookups by house/orientation numbers

Reduces full table scans and significantly improves query performance.